### PR TITLE
Sa 1894

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,9 @@
 version: '3'
+volumes:
+  mysql-data:
+    driver: local
+  scan-log:
+    driver: local
 services:
   mysqldb:
     image: mysql
@@ -8,13 +13,15 @@ services:
       MYSQL_DATABASE: jackhammer_production
     ports:
       - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
   web:
     build: ./web
     volumes:
       - '.:/jackhammer'
     ports:
       - "5000:3000"
-    command: bash -c "bundle exec sidekiq -C config/sidekiq.yml -d && bundle exec puma -e production -b tcp://0.0.0.0:3000"
+    command: bundle exec puma -e production -b tcp://0.0.0.0:3000
     environment:
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY_BASE=454ab84a2554a5e715db90c7560a06d8a20811d614e7313de05495ecdeac9614c4c3d263df1a5892b92d6c32ea06d4defbd2492c598e8295f89b8b316db25842
@@ -24,6 +31,30 @@ services:
       - MYSQL_HOST=mysqldb
       - MYSQL_USER=root
       - MYSQL_PASSWORD=root
+    volumes:
+      - scan-log:/home/app/log/scans
+    links:
+      - mysqldb:mysqldb
+      - redis:redis
+    depends_on:
+      - mysqldb
+      - redis
+  worker:
+    build: ./web
+    volumes:
+      - '.:/jackhammer'
+    command: bundle exec sidekiq -C config/sidekiq.yml
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - SECRET_KEY_BASE=454ab84a2554a5e715db90c7560a06d8a20811d614e7313de05495ecdeac9614c4c3d263df1a5892b92d6c32ea06d4defbd2492c598e8295f89b8b316db25842
+      - RAILS_SERVE_STATIC_FILES=true
+      - RAILS_ENV=production
+      - MYSQL_DB=jackhammer_production
+      - MYSQL_HOST=mysqldb
+      - MYSQL_USER=root
+      - MYSQL_PASSWORD=root
+    volumes:
+      - scan-log:/home/app/log/scans
     links:
       - mysqldb:mysqldb
       - redis:redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     build: ./web
     volumes:
       - '.:/jackhammer'
+      - scan-log:/home/app/log/scans
     ports:
       - "5000:3000"
     command: bundle exec puma -e production -b tcp://0.0.0.0:3000
@@ -31,8 +32,6 @@ services:
       - MYSQL_HOST=mysqldb
       - MYSQL_USER=root
       - MYSQL_PASSWORD=root
-    volumes:
-      - scan-log:/home/app/log/scans
     links:
       - mysqldb:mysqldb
       - redis:redis
@@ -43,6 +42,7 @@ services:
     build: ./web
     volumes:
       - '.:/jackhammer'
+      - scan-log:/home/app/log/scans
     command: bundle exec sidekiq -C config/sidekiq.yml
     environment:
       - REDIS_URL=redis://redis:6379
@@ -53,8 +53,6 @@ services:
       - MYSQL_HOST=mysqldb
       - MYSQL_USER=root
       - MYSQL_PASSWORD=root
-    volumes:
-      - scan-log:/home/app/log/scans
     links:
       - mysqldb:mysqldb
       - redis:redis

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -77,6 +77,5 @@ ADD app/ /home/app
 WORKDIR /home/app
 #create tmp dir
 RUN mkdir -p tmp/pids
-RUN mkdir -p log/scans
 # expose HTTP
 EXPOSE 3000


### PR DESCRIPTION
This change needs a manual migration step.

Stop jackhammer
```
$ cd /srv/jackhammer
$ sudo docker-compose stop
```

*mysqldb*
1. Launch mysqldb container with mounting mysql-data volume to /mysql-data.
2. Login mysqldb.
3. Stop mysql-server.
4. Move /var/lib/mysql/* to mounted volume (/mysql-data/*).

*web (worker)*
1. Launch web container with mounting scan-log volume to /scan-log.
2. Login web.
3. Stop sidekiq and puma.
4. Move /home/app/logs/scans/* to a mounted volume (/scan-lot/*).

Rebuild jackhammer container
```
$ cd /srv/jackhammer
$ sudo ./docker-build.sh
```